### PR TITLE
Fixed issue with folder names that contain quotes and are being used in a directory table/list popup

### DIFF
--- a/filer/admin/folderadmin.py
+++ b/filer/admin/folderadmin.py
@@ -5,7 +5,7 @@ from django.core.exceptions import ValidationError
 from django.contrib.admin import helpers
 from django.contrib.admin.util import quote, unquote, capfirst
 from django.contrib import messages
-from django.template.defaultfilters import urlencode
+from django.utils.http import urlquote
 from filer.admin.patched.admin_utils import get_deleted_objects
 from django.core.exceptions import PermissionDenied
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
@@ -37,7 +37,6 @@ from filer.settings import FILER_STATICMEDIA_PREFIX, FILER_PAGINATE_BY
 from filer.utils.filer_easy_thumbnails import FilerActionThumbnailer
 from filer.thumbnail_processors import normalize_subject_location
 from django.conf import settings as django_settings
-import urllib
 import os
 import itertools
 import inspect
@@ -394,7 +393,7 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
                 'current_url': request.path,
                 'title': u'Directory listing for %s' % folder.name,
                 'search_string': ' '.join(search_terms),
-                'q': urlencode(q),
+                'q': urlquote(q),
                 'show_result_count': show_result_count,
                 'limit_search_to_folder': limit_search_to_folder,
                 'is_popup': popup_status(request),

--- a/filer/models/foldermodels.py
+++ b/filer/models/foldermodels.py
@@ -1,4 +1,6 @@
 #-*- coding: utf-8 -*-
+import urllib
+
 try:
     from django.contrib.auth import get_user_model
     User = get_user_model()

--- a/filer/models/foldermodels.py
+++ b/filer/models/foldermodels.py
@@ -9,7 +9,6 @@ from django.core import urlresolvers
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import Q
-from django.template.defaultfilters import urlencode
 from django.utils.http import urlquote
 from django.utils.translation import ugettext_lazy as _
 from filer.models import mixins

--- a/filer/models/foldermodels.py
+++ b/filer/models/foldermodels.py
@@ -148,6 +148,10 @@ class Folder(models.Model, mixins.IconsMixin):
     def pretty_logical_path(self):
         return u"/%s" % u"/".join([f.name for f in self.logical_path+[self]])
 
+    @property
+    def quoted_logical_path(self):
+        return u"/%s" % u"/".join([urllib.quote(f.name) for f in self.logical_path+[self]])
+
     def has_edit_permission(self, request):
         return self.has_generic_permission(request, 'edit')
 

--- a/filer/models/foldermodels.py
+++ b/filer/models/foldermodels.py
@@ -1,6 +1,4 @@
 #-*- coding: utf-8 -*-
-import urllib
-
 try:
     from django.contrib.auth import get_user_model
     User = get_user_model()
@@ -11,6 +9,8 @@ from django.core import urlresolvers
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import Q
+from django.template.defaultfilters import urlencode
+from django.utils.http import urlquote
 from django.utils.translation import ugettext_lazy as _
 from filer.models import mixins
 from filer import settings as filer_settings
@@ -152,7 +152,7 @@ class Folder(models.Model, mixins.IconsMixin):
 
     @property
     def quoted_logical_path(self):
-        return u"/%s" % u"/".join([urllib.quote(f.name) for f in self.logical_path+[self]])
+        return urlquote(self.pretty_logical_path)
 
     def has_edit_permission(self, request):
         return self.has_generic_permission(request, 'edit')

--- a/filer/templates/admin/filer/folder/directory_listing.html
+++ b/filer/templates/admin/filer/folder/directory_listing.html
@@ -77,7 +77,7 @@
             <span class="small quiet">({% blocktrans count folder.children_count as counter %}1 folder{% plural %}{{ counter }} folders{% endblocktrans %}, {% blocktrans count folder.file_count as counter %}1 file{% plural %}{{ counter }} files{% endblocktrans %})</span>
             <span>
                 {% if is_popup %}
-                    {% if select_folder and folder.file_type == 'Folder' %}<a class="insertlink insertlinkButton" href="" onclick="opener.dismissRelatedFolderLookupPopup(window, {{ folder.id }}, '{{ folder.pretty_logical_path }}'); return false;" >&nbsp;</a>{% endif %}
+                    {% if select_folder and folder.file_type == 'Folder' %}<a class="insertlink insertlinkButton" href="" onclick="opener.dismissRelatedFolderLookupPopup(window, {{ folder.id }}, '{{ folder.quoted_logical_path }}'); return false;" >&nbsp;</a>{% endif %}
                 {% else %}<a style="display: block; float: right;" class="changelink" href="{% url 'admin:filer_folder_change' folder.id %}" title="{% trans "Change current folder details" %}">{% trans "Change" %}</a>{% endif %}
             </span>
         </h1>

--- a/filer/templates/admin/filer/folder/directory_table.html
+++ b/filer/templates/admin/filer/folder/directory_table.html
@@ -18,7 +18,7 @@
         {% for item in paginated_items.object_list %}
             {% if item.file_type == 'Folder' or item.file_type == 'DummyFolder' %}{% with item as subfolder%}
             <tr class="{% cycle rowcolors %}">
-                <td>{% if select_folder and item.file_type == 'Folder' %}<a class="insertlink insertlinkButton" href="" onclick="opener.dismissRelatedFolderLookupPopup(window, {{ subfolder.id }}, '{{ subfolder.pretty_logical_path }}'); return false;" >&nbsp;</a>{% else %}{% if action_form and item.pk and not is_popup %}<input type="checkbox" class="action-select" value="folder-{{ item.pk }}" name="_selected_action" />{% endif %}{% endif %}</td>
+                <td>{% if select_folder and item.file_type == 'Folder' %}<a class="insertlink insertlinkButton" href="" onclick="opener.dismissRelatedFolderLookupPopup(window, {{ subfolder.id }}, '{{ subfolder.quoted_logical_path }}'); return false;" >&nbsp;</a>{% else %}{% if action_form and item.pk and not is_popup %}<input type="checkbox" class="action-select" value="folder-{{ item.pk }}" name="_selected_action" />{% endif %}{% endif %}</td>
                 <!-- DirIcon -->
                 <td><a href="{{ subfolder.get_admin_directory_listing_url_path }}{% if is_popup %}?_popup=1{% if select_folder %}&select_folder=1{% endif %}{% endif %}" title="{% blocktrans with subfolder.name as item_label %}Change '{{ item_label }}' folder details{% endblocktrans %}"><img src="{{ subfolder.icons.48 }}" alt="{% trans "Folder Icon" %}" /></a></td>
                 <!-- Directory details -->

--- a/filer/tests/models.py
+++ b/filer/tests/models.py
@@ -176,7 +176,14 @@ class FilerApiTests(TestCase):
         self.assertTrue(storage.exists(name))
 
     def test_folder_quoted_logical_path(self):
-        root_folder = Folder.objects.create(name="Foo's Bar", parent=None)
-        child = Folder.objects.create(name='Bar"s Foo', parent=root_folder)
+        root_folder = Folder.objects.create(name=u"Foo's Bar", parent=None)
+        child = Folder.objects.create(name=u'Bar"s Foo', parent=root_folder)
         self.assertEqual(child.quoted_logical_path, u'/Foo%27s%20Bar/Bar%22s%20Foo')
+
+    def test_folder_quoted_logical_path_with_unicode(self):
+        root_folder = Folder.objects.create(name=u"Foo's Bar", parent=None)
+        child = Folder.objects.create(name=u'Bar"s 日本 Foo', parent=root_folder)
+        self.assertEqual(child.quoted_logical_path,
+                         u'/Foo%27s%20Bar/Bar%22s%20%E6%97%A5%E6%9C%AC%20Foo')
+
 

--- a/filer/tests/models.py
+++ b/filer/tests/models.py
@@ -174,3 +174,9 @@ class FilerApiTests(TestCase):
 
         # file should still be here
         self.assertTrue(storage.exists(name))
+
+    def test_folder_quoted_logical_path(self):
+        root_folder = Folder.objects.create(name="Foo's Bar", parent=None)
+        child = Folder.objects.create(name='Bar"s Foo', parent=root_folder)
+        self.assertEqual(child.quoted_logical_path, u'/Foo%27s%20Bar/Bar%22s%20Foo')
+


### PR DESCRIPTION
If a folder contains a single quote and is being used in a folder directory/list popup
the generated onclick attribute for the insert link contains broken javascript:
onclick="opener.dismissRelatedFolderLookupPopup(window, 3, '/Foo's Bar/whatever'); return false;"

Added a new method that returnes a url quoted pretty logical path. This can be used for the onclick attributes.
